### PR TITLE
Swap dark bits of background to fix sidebar

### DIFF
--- a/variables.less
+++ b/variables.less
@@ -1,7 +1,7 @@
 @import '../Vector/variables.less';
 
 @brand-primary: #deead8;
-@brand-secondary: #302e30;
+@brand-secondary: #f6f6f6;
 @text-color: #1e2021;
 @nav-toggle-color: darken(@brand-primary, 60%);
 @new-link-color: #7f7f7f;


### PR DESCRIPTION
Swap the dark bits to a light grey to allow us to read the light text in the left hand sidebar and in the footer.

Quick fix to make the style less obviously broken. We need to investigate why the skin has reverted to looking like vector, with all our nice customisations overriden. The dark background parts are the only surviving customisations actually (but not working well with the text)