### PR TITLE
Fix skin for 1.35

### DIFF
--- a/OSMFoundationSkin.php
+++ b/OSMFoundationSkin.php
@@ -5,13 +5,12 @@
 * @file
 * @ingroup Skins
 */
-wfLoadSkin('Vector');
 
 /**
  * SkinTemplate class for OSMF skin
  * @ingroup Skins
  */
-class SkinOSMFoundation extends SkinVector {
+class SkinOSMFoundation extends SkinTemplate {
 
     var $skinname = 'osmfoundation', $stylename = 'OSMFoundation', $template = 'OSMFoundationTemplate';
 

--- a/OSMFoundationSkin.php
+++ b/OSMFoundationSkin.php
@@ -5,7 +5,6 @@
 * @file
 * @ingroup Skins
 */
-
 wfLoadSkin('Vector');
 
 /**
@@ -15,14 +14,6 @@ wfLoadSkin('Vector');
 class SkinOSMFoundation extends SkinVector {
 
     var $skinname = 'osmfoundation', $stylename = 'OSMFoundation', $template = 'OSMFoundationTemplate';
-
-    /**
-     * @param $out OutputPage object
-     */
-    function setupSkinUserCss( OutputPage $out ) {
-        parent::setupSkinUserCss( $out );
-        $out->addModuleStyles( "skins.osmfoundation" );
-    }
 
     /**
      * This function adds JavaScript via ResourceLoader and
@@ -35,5 +26,6 @@ class SkinOSMFoundation extends SkinVector {
         parent::initPage( $out );
         $out->addMeta( 'viewport', 'width=device-width, initial-scale=1.0' );
         $out->addModules( 'skins.osmfoundation.js' );
+        $out->addModuleStyles( "skins.osmfoundation" );
     }
 }

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -111,6 +111,182 @@ class OSMFoundationTemplate extends BaseTemplate {
      * @param array $elements
      */
     protected function renderNavigation( array $elements ) {
+        // Render elements
+        foreach ( $elements as $name => $element ) {
+            switch ( $element ) {
+                case 'NAMESPACES':
+                    ?>
+                    <div id="p-namespaces" role="navigation" class="vectorTabs<?php
+                    if ( count( $this->data['namespace_urls'] ) == 0 ) {
+                        echo ' emptyPortlet';
+                    }
+                    ?>" aria-labelledby="p-namespaces-label">
+                        <h3 id="p-namespaces-label"><?php $this->msg( 'namespaces' ) ?></h3>
+                        <ul<?php $this->html( 'userlangattributes' ) ?>>
+                            <?php
+                            foreach ( $this->data['namespace_urls'] as $key => $item ) {
+                                echo $this->makeListItem( $key, $item, [
+                                    'vector-wrap' => true,
+                                ] );
+                            }
+                            ?>
+                        </ul>
+                    </div>
+                    <?php
+                    break;
+                case 'VARIANTS':
+                    ?>
+                    <div id="p-variants" role="navigation" class="vectorMenu<?php
+                    if ( count( $this->data['variant_urls'] ) == 0 ) {
+                        echo ' emptyPortlet';
+                    }
+                    ?>" aria-labelledby="p-variants-label">
+                        <?php
+                        // Replace the label with the name of currently chosen variant, if any
+                        $variantLabel = $this->getMsg( 'variants' )->text();
+                        foreach ( $this->data['variant_urls'] as $item ) {
+                            if ( isset( $item['class'] ) && stripos( $item['class'], 'selected' ) !== false ) {
+                                $variantLabel = $item['text'];
+                                break;
+                            }
+                        }
+                        ?>
+                        <input type="checkbox" class="vectorMenuCheckbox" aria-labelledby="p-variants-label" />
+                        <h3 id="p-variants-label">
+                            <span><?php echo htmlspecialchars( $variantLabel ) ?></span>
+                        </h3>
+                        <ul class="menu">
+                            <?php
+                            foreach ( $this->data['variant_urls'] as $key => $item ) {
+                                echo $this->makeListItem( $key, $item );
+                            }
+                            ?>
+                        </ul>
+                    </div>
+                    <?php
+                    break;
+                case 'VIEWS':
+                    ?>
+                    <div id="p-views" role="navigation" class="vectorTabs<?php
+                    if ( count( $this->data['view_urls'] ) == 0 ) {
+                        echo ' emptyPortlet';
+                    }
+                    ?>" aria-labelledby="p-views-label">
+                        <h3 id="p-views-label"><?php $this->msg( 'views' ) ?></h3>
+                        <ul<?php $this->html( 'userlangattributes' ) ?>>
+                            <?php
+                            foreach ( $this->data['view_urls'] as $key => $item ) {
+                                echo $this->makeListItem( $key, $item, [
+                                    'vector-wrap' => true,
+                                    'vector-collapsible' => true,
+                                ] );
+                            }
+                            ?>
+                        </ul>
+                    </div>
+                    <?php
+                    break;
+                case 'ACTIONS':
+                    ?>
+                    <div id="p-cactions" role="navigation" class="vectorMenu<?php
+                    if ( count( $this->data['action_urls'] ) == 0 ) {
+                        echo ' emptyPortlet';
+                    }
+                    ?>" aria-labelledby="p-cactions-label">
+                        <input type="checkbox" class="vectorMenuCheckbox" aria-labelledby="p-cactions-label" />
+                        <h3 id="p-cactions-label"><span><?php
+                            $this->msg( 'vector-more-actions' )
+                        ?></span></h3>
+                        <ul class="menu"<?php $this->html( 'userlangattributes' ) ?>>
+                            <?php
+                            foreach ( $this->data['action_urls'] as $key => $item ) {
+                                echo $this->makeListItem( $key, $item );
+                            }
+                            ?>
+                        </ul>
+                    </div>
+                    <?php
+                    break;
+                case 'PERSONAL':
+                    ?>
+                    <div id="p-personal" role="navigation"<?php
+                    if ( count( $this->data['personal_urls'] ) == 0 ) {
+                        echo ' class="emptyPortlet"';
+                    }
+                    ?> aria-labelledby="p-personal-label">
+                        <h3 id="p-personal-label"><?php $this->msg( 'personaltools' ) ?></h3>
+                        <ul<?php $this->html( 'userlangattributes' ) ?>>
+                            <?php
+                            $notLoggedIn = '';
+
+                            if ( !$this->getSkin()->getUser()->isRegistered() &&
+                                User::groupHasPermission( '*', 'edit' )
+                            ) {
+                                $notLoggedIn =
+                                    Html::element( 'li',
+                                        [ 'id' => 'pt-anonuserpage' ],
+                                        $this->getMsg( 'notloggedin' )->text()
+                                    );
+                            }
+
+                            $personalTools = $this->getPersonalTools();
+
+                            $langSelector = '';
+                            if ( array_key_exists( 'uls', $personalTools ) ) {
+                                $langSelector = $this->makeListItem( 'uls', $personalTools[ 'uls' ] );
+                                unset( $personalTools[ 'uls' ] );
+                            }
+
+                            echo $langSelector;
+                            echo $notLoggedIn;
+                            foreach ( $personalTools as $key => $item ) {
+                                echo $this->makeListItem( $key, $item );
+                            }
+                            ?>
+                        </ul>
+                    </div>
+                    <?php
+                    break;
+                case 'SEARCH':
+                    ?>
+                    <div id="p-search" role="search">
+                        <h3<?php $this->html( 'userlangattributes' ) ?>>
+                            <label for="searchInput"><?php $this->msg( 'search' ) ?></label>
+                        </h3>
+                        <form action="<?php $this->text( 'wgScript' ) ?>" id="searchform">
+                            <div<?php echo $this->config->get( 'VectorUseSimpleSearch' ) ? ' id="simpleSearch"' : '' ?>>
+                                <?php
+                                echo $this->makeSearchInput( [ 'id' => 'searchInput' ] );
+                                echo Html::hidden( 'title', $this->get( 'searchtitle' ) );
+                                /* We construct two buttons (for 'go' and 'fulltext' search modes),
+                                 * but only one will be visible and actionable at a time (they are
+                                 * overlaid on top of each other in CSS).
+                                 * * Browsers will use the 'fulltext' one by default (as it's the
+                                 *   first in tree-order), which is desirable when they are unable
+                                 *   to show search suggestions (either due to being broken or
+                                 *   having JavaScript turned off).
+                                 * * The mediawiki.searchSuggest module, after doing tests for the
+                                 *   broken browsers, removes the 'fulltext' button and handles
+                                 *   'fulltext' search itself; this will reveal the 'go' button and
+                                 *   cause it to be used.
+                                 */
+                                echo $this->makeSearchButton(
+                                    'fulltext',
+                                    [ 'id' => 'mw-searchButton', 'class' => 'searchButton mw-fallbackSearchButton' ]
+                                );
+                                echo $this->makeSearchButton(
+                                    'go',
+                                    [ 'id' => 'searchButton', 'class' => 'searchButton' ]
+                                );
+                                ?>
+                            </div>
+                        </form>
+                    </div>
+                    <?php
+
+                    break;
+            }
+        }
     }
 
     /**

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -385,7 +385,7 @@ class OSMFoundationTemplate extends BaseTemplate {
                         <span></span>
                     </div>
                 </button>
-                <div id="p-logo" role="banner"><a class="logo" href="<?php
+                <div id="p-logo" role="banner"><a class="logo mw-wiki-logo" href="<?php
                     echo htmlspecialchars( $this->data['nav_urls']['mainpage']['href'] )
                     ?>" <?php
                     echo Xml::expandAttributes( Linker::tooltipAndAccesskeyAttribs( 'p-logo' ) )

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -130,7 +130,7 @@ class OSMFoundationTemplate extends BaseTemplate {
                     ?>" <?php
                     echo Xml::expandAttributes( Linker::tooltipAndAccesskeyAttribs( 'p-logo' ) )
                     ?>></a></div>
-                <?php $this->renderNav( $this->data['sidebar']['MENUBAR'] ); ?>
+                <?php $this->renderNav( $this->data['sidebar']['MENUBAR'] ?? $this->data['sidebar']['navigation'] ?? [] ); ?>
             </div>
         </header>
         <div class="main-wrapper">
@@ -321,6 +321,12 @@ class OSMFoundationTemplate extends BaseTemplate {
                 }
                 ?>
             </ul>
+            <?php
+        } else {
+            ?>
+            <div class="mainnav">
+                Site misconfigured: Please add "MENUBAR" section to [[MediaWiki:Sidebar]].
+            </div>
             <?php
         }
     }

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -240,7 +240,7 @@ class OSMFoundationTemplate extends BaseTemplate {
                             echo $langSelector;
                             echo $notLoggedIn;
                             foreach ( $personalTools as $key => $item ) {
-                                echo $this->makeListItem( $key, $item );
+                                echo $this->makeListItem( $key, $item ) . '&nbsp;';
                             }
                             ?>
                         </ul>

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -495,7 +495,7 @@ class OSMFoundationTemplate extends BaseTemplate {
                     <?php
                     foreach ( $info as $link ) {
                     ?>
-                    <li id="footer-<?php echo $category ?>-<?php echo $link ?>"><?php $this->html( $link ) ?></li>
+                    <li id="footer--<?php echo $link ?>"><?php $this->html( $link ) ?></li>
                     <?php
                     }
                     ?>

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -11,6 +11,24 @@
  * @ingroup Skins
  */
 class OSMFoundationTemplate extends BaseTemplate {
+
+    /**
+     * Render a series of portals
+     *
+     * @param array $portals
+     */
+    protected function renderPortals( array $portals ) {
+    }
+
+    /**
+     * Render one or more navigations elements by name, automatically reversed by css
+     * when UI is in RTL mode
+     *
+     * @param array $elements
+     */
+    protected function renderNavigation( array $elements ) {
+    }
+
     /**
      * Outputs the entire contents of the (X)HTML page
      */

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -37,7 +37,7 @@ class OSMFoundationTemplate extends BaseTemplate {
 
             $xmlID = isset( $link['id'] ) ? $link['id'] : 'ca-' . $xmlID;
             $nav[$section][$key]['attributes'] =
-              ' id="' . Sanitizer::escapeId( $xmlID ) . '"';
+              ' id="' . Sanitizer::escapeIdForAttribute( $xmlID ) . '"';
             if ( $link['class'] ) {
               $nav[$section][$key]['attributes'] .=
                 ' class="' . htmlspecialchars( $link['class'] ) . '"';

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -10,7 +10,7 @@
  * QuickTemplate class for OSMF skin
  * @ingroup Skins
  */
-class OSMFoundationTemplate extends VectorTemplate {
+class OSMFoundationTemplate extends BaseTemplate {
     /**
      * Outputs the entire contents of the (X)HTML page
      */

--- a/OSMFoundationTemplate.php
+++ b/OSMFoundationTemplate.php
@@ -18,17 +18,26 @@ class OSMFoundationTemplate extends BaseTemplate {
         // Build additional attributes for navigation urls
         $nav = $this->data['content_navigation'];
 
-        if ( $this->config->get( 'VectorUseIconWatch' ) ) {
-          $mode = $this->getSkin()->getUser()->isWatched( $this->getSkin()->getRelevantTitle() )
-            ? 'unwatch'
-            : 'watch';
+        $user = $this->getSkin()->getUser();
+        $relevantTitle = $this->getSkin()->getRelevantTitle();
+        $isWatched = false;
+        // Use method_exists to maintain compatibility with MediaWiki 1.30
+        if ( method_exists( $user, 'isWatched' ) ) {
+            $isWatched = $user->isWatched( $relevantTitle );
+        } else {
+            $instance = MediaWiki\MediaWikiServices::getInstance();
+            $isWatched = $instance->getWatchedItemStore()->isWatched(
+                $user,
+                $relevantTitle
+            );
+        }
+        $mode = $isWatched ? 'unwatch' : 'watch';
 
-          if ( isset( $nav['actions'][$mode] ) ) {
+        if ( isset( $nav['actions'][$mode] ) ) {
             $nav['views'][$mode] = $nav['actions'][$mode];
             $nav['views'][$mode]['class'] = $nav['views'][$mode]['class'];
             $nav['views'][$mode]['primary'] = true;
             unset( $nav['actions'][$mode] );
-          }
         }
 
         $xmlID = '';

--- a/dropdowns.less
+++ b/dropdowns.less
@@ -1,0 +1,131 @@
+/* Variants and Actions */
+.vectorMenu {
+	direction: ltr;
+	float: left;
+	cursor: pointer;
+	position: relative;
+	line-height: 1.125em;
+
+	h3 {
+		span {
+			color: @color-nav-subtle;
+			position: relative;
+			display: block;
+			padding-left: 0.615em;
+			padding-top: 1.25em;
+			padding-right: 16px;
+			font-size: @font-size-tabs;
+			font-weight: normal;
+
+			&:after {
+				content: '';
+				position: absolute;
+				top: 1.25em;
+				right: 0;
+				bottom: 0;
+				left: 0;
+				background-image: background-image( 'images/arrow-down.svg' );
+				background-position: 100% 50%;
+				background-repeat: no-repeat;
+				// Modify the color of the image from the default #222 to approx. #444 to match the text.
+				opacity: 0.85;
+			}
+		}
+
+		&:hover span,
+		&:focus span {
+			color: @color-base;
+
+			&:after {
+				opacity: 1;
+			}
+		}
+	}
+
+	.menu {
+		list-style: none none;
+		background-color: @background-color-base;
+		clear: both;
+		// Match the width of the dropdown "heading" (the tab)
+		min-width: 100%;
+		position: absolute;
+		top: 2.5em;
+		left: -@border-width-base;
+		margin: 0;
+		border: @border-width-base @border-style-base @border-color-base;
+		border-top-width: 0;
+		padding: 0;
+		box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.1 );
+		text-align: left;
+		opacity: 0;
+		visibility: hidden;
+		.transition( opacity 100ms );
+		// Menus must overlap indicators (z-index: 1) and VisualEditor toolbar (z-index: 2)
+		z-index: 2;
+	}
+
+	&:hover .menu {
+		opacity: 1;
+		visibility: visible;
+	}
+
+	// This is in a separate block, so that browsers supporting :hover but not :checked still apply the rule above
+	// Support: IE8
+	.vectorMenuCheckbox:checked ~ .menu {
+		opacity: 1;
+		visibility: visible;
+	}
+
+	li {
+		padding: 0;
+		margin: 0;
+		text-align: left;
+		line-height: 1em;
+
+		a {
+			color: @footer-background-color;
+			display: block;
+			padding: 0.625em;
+			white-space: nowrap;
+			cursor: pointer;
+			font-size: @font-size-tabs;
+		}
+	}
+
+	.selected a,
+	.selected a:visited {
+		color: lighten( @footer-background-color, 80% );
+		text-decoration: none;
+	}
+}
+
+// Invisible checkbox covering the dropdown menu handle
+.vectorMenuCheckbox {
+	cursor: pointer;
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: 1;
+	opacity: 0;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+	// Hide the checkbox completely in browsers that don't support :checked
+	display: none;
+
+	:not( :checked ) > & {
+		// When the browser supports :checked, display it
+		display: block;
+	}
+
+	&:checked + h3 span:after {
+		transform: scaleY( -1 );
+	}
+
+	&:focus + h3 {
+		// Simulate browser focus ring
+		outline: dotted 1px; // Firefox style
+		outline: auto -webkit-focus-ring-color; // Webkit style
+	}
+}

--- a/img/search.svg
+++ b/img/search.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="13">
+	<g fill="none" stroke="#54595d" stroke-width="2">
+		<path d="M11.29 11.71l-4-4"/>
+		<circle cx="5" cy="5" r="4"/>
+	</g>
+</svg>

--- a/osmfoundation.less
+++ b/osmfoundation.less
@@ -30,15 +30,24 @@
 	.mixin-screen-reader-text;
 }
 
+@import 'dropdowns.less';
+@import 'search.less';
+
 html,
 body {
+    margin: 0;
+    padding: 0;
     min-width: 320px;
     color: @text-color;
-    background-color: @brand-secondary !important;
+    background-color: @footer-background-color !important;
     font-family: osmftext, sans-serif !important;
     font-size: 16px !important;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+    text-decoration: none;
 }
 
 h1,
@@ -452,11 +461,23 @@ header.fixed .mainnav li a {
 }
 
 footer {
-    background-color: @brand-secondary;
     max-width: 1000px;
     margin: auto;
     padding: 30px 1.5em;
     color: @footer-text-color;
+
+    ul {
+        list-style: none none;
+        margin: 0;
+        padding: 0;
+    }
+
+    li {
+        color: @color-base;
+        margin: 0;
+        padding: 0.5em 0;
+        font-size: @font-size-footer;
+    }
 
     .first-row,
     .second-row {
@@ -497,6 +518,10 @@ footer {
         margin: 0;
         font-size: 0.9em;
         width: 100%;
+
+        li {
+            color: white;
+        }
 
         @media (min-width: 768px) {
             width: 50%;
@@ -620,7 +645,7 @@ footer {
         }
 
         li a {
-            color: @footer-text-color;
+            color: @footer-background-color;
             padding: 0.8em 1.3em;
         }
 

--- a/osmfoundation.less
+++ b/osmfoundation.less
@@ -1045,3 +1045,18 @@ table.wikitable {
     background-color: lighten(@brand-secondary, 80%);
     border-color: lighten(@brand-secondary, 70%);
 }
+
+/* Logo */
+#p-logo {
+	width: 10em;
+	height: 160px;
+
+	a {
+		display: block;
+		width: 10em;
+		height: 160px;
+		background-repeat: no-repeat;
+		background-position: center center;
+		text-decoration: none;
+	}
+}

--- a/osmfoundation.less
+++ b/osmfoundation.less
@@ -1,3 +1,4 @@
+@import 'mediawiki.mixins.less';
 @import 'variables.less';
 
 @font-face {
@@ -14,6 +15,19 @@
          url('fonts/osmftext-bold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
+}
+/* Hide, but keep accessible for screen-readers */
+#p-personal h3,
+.vectorTabs h3,
+#p-search h3,
+#footer h2,
+#mw-navigation h2 {
+	position: absolute;
+	top: -9999px;
+}
+
+.mw-jump:not( :focus ) {
+	.mixin-screen-reader-text;
 }
 
 html,

--- a/search.less
+++ b/search.less
@@ -1,0 +1,115 @@
+@import 'mediawiki.mixins';
+@import 'mediawiki.ui/variables';
+
+/* Search */
+#p-search {
+	float: left;
+	margin-right: 0.5em;
+	margin-left: 0.5em;
+
+	h3 {
+		.mixin-screen-reader-text;
+	}
+
+	form {
+		margin: 0.5em 0 0;
+	}
+}
+
+#simpleSearch {
+	display: block;
+	width: 13.2em;
+	width: 20vw; /* responsive width */
+	min-width: 5em;
+	max-width: 20em;
+	height: 100%;
+	margin-top: 0;
+	position: relative;
+	min-height: 1px; /* Gotta trigger hasLayout for IE7 */
+
+	// Styles for both the search input and the button.
+	input {
+		// Support IE6-8: Fallback for browsers, which don't support `rgba()`.
+		background-color: @background-color-base;
+		background-color: rgba( 0, 0, 0, 0 );
+		color: @color-base--emphasized;
+		margin: 0;
+	}
+}
+
+// The search input.
+
+#searchInput {
+	width: 100%;
+	.box-sizing( border-box );
+	border: @border-width-base @border-style-base @colorGray10;
+	border-radius: @borderRadius;
+	// `padding-right` equals to `#searchbutton` width below.
+	padding: 0.4em @width-search-button 0.4em 0.4em;
+	box-shadow: @boxShadowWidget;
+	font-size: @font-size-search-input;
+	direction: ltr;
+	.transition( ~'border-color 250ms, box-shadow 250ms' );
+	// Support: Webkit browsers. Undo the proprietary styles applied to `type=search` fields,
+	// we provide our own.
+	-webkit-appearance: textfield;
+
+	#simpleSearch:hover & {
+		border-color: @colorGray7;
+	}
+
+	&:focus,
+	#simpleSearch:hover &:focus {
+		outline: 0;
+		border-color: @colorProgressive;
+		box-shadow: @boxShadowProgressiveFocus;
+	}
+
+	.mixin-placeholder( {
+		color: @colorGray7;
+		opacity: 1;
+	} );
+
+	&::-webkit-search-decoration,
+	&::-webkit-search-cancel-button,
+	&::-webkit-search-results-button,
+	&::-webkit-search-results-decoration {
+		-webkit-appearance: textfield;
+	}
+}
+
+// The buttons. They are displayed in the same position, and if both are
+// present the fulltext search one obscures the 'Go' one.
+#searchButton,
+#mw-searchButton {
+	position: absolute;
+	top: @border-width-base;
+	bottom: @border-width-base;
+	// `@border-width-base * 2` is in regards to harmonize position start and end.
+	right: @border-width-base;
+	min-width: 24px;
+	width: @width-search-button;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	// Equal `font-size` to search input for `padding` calculationo.
+	font-size: @font-size-search-input;
+	/* Opera 12 on RTL flips the text in a funny way without this. */
+	/* @noflip */
+	direction: ltr;
+	/* Hide button text and replace it with the image. */
+	text-indent: -99999px;
+	white-space: nowrap;
+	overflow: hidden;
+	z-index: 1;
+}
+
+#searchButton {
+	background-image: url( 'img/search.svg' );
+	background-position: center center;
+	background-repeat: no-repeat;
+}
+
+#mw-searchButton {
+	z-index: 1;
+}

--- a/skin.json
+++ b/skin.json
@@ -22,8 +22,11 @@
     },
     "ResourceModules": {
         "skins.osmfoundation": {
+            "class": "ResourceLoaderSkinModule",
+            "features": {
+                "logo": true
+            },
             "targets": [ "desktop", "mobile" ],
-            "position": "top",
             "styles": {
                 "osmfoundation.less": {}
             }

--- a/skin.json
+++ b/skin.json
@@ -6,6 +6,7 @@
     "namemsg": "skinname-osmf",
     "license-name": "GPL-2.0+",
     "type": "skin",
+    "manifest_version": 2,
     "requires": {
         "MediaWiki": ">= 1.29.0"
     },

--- a/skin.json
+++ b/skin.json
@@ -24,6 +24,7 @@
         "skins.osmfoundation": {
             "class": "ResourceLoaderSkinModule",
             "features": {
+                "interface": true,
                 "logo": true
             },
             "targets": [ "desktop", "mobile" ],

--- a/variables.less
+++ b/variables.less
@@ -5,6 +5,7 @@
 @text-color: #1e2021;
 @nav-toggle-color: darken(@brand-primary, 60%);
 @new-link-color: #7f7f7f;
+@footer-background-color: #302e30;
 @footer-text-color: lighten(@brand-secondary, 70%);
 
 @ui-button-color: #fff;


### PR DESCRIPTION
This begins work on fixing the skin for 1.35. 
What happened is that Vector code was completely rewritten in 1.35. To rectify this I had to  use Vector's 1.34 branch as a reference to restore the code needed for this skin to work.

While there, since I'm using 1.37 I had to make various other changes to address other issues that are going to break in future.

The issues with broken / deprecated code are addressed in this patchset (feel free to merge the work so far), but I still need to fix some of the styles (particularly the footer). For that I need to see some screenshots of how this is supposed to behave.
I'll work on that later.
 
cc @tomhughes 

Fixes: #24